### PR TITLE
Add trackbar settings save/load

### DIFF
--- a/blob_tracker.py
+++ b/blob_tracker.py
@@ -4,6 +4,8 @@ import tkinter as tk
 from tkinter import filedialog
 from tqdm import tqdm
 import moviepy as mpe
+import json
+import os
 
 # Select file dialogs
 def select_file():
@@ -33,19 +35,44 @@ def create_control_panel():
 
 
 def show_help_panel():
-    help_img = np.zeros((220, 400, 3), dtype=np.uint8)
+    help_img = np.zeros((260, 400, 3), dtype=np.uint8)
     lines = [
         "Deslizadores en 'Controls':",
         "Umbral - binarizacion",
         "Area minima - tamano minimo",
         "Distancia max - seguimiento",
         "Max blobs - limite objetos",
+        "s: guardar  l: cargar",
         "e: exportar  q: salir",
     ]
     for i, line in enumerate(lines):
         cv2.putText(help_img, line, (10, 30 + i*30), cv2.FONT_HERSHEY_SIMPLEX,
                     0.5, (255, 255, 255), 1)
     cv2.imshow('Ayuda', help_img)
+
+
+# Trackbar settings persistence
+SETTINGS_FILE = 'trackbar_settings.json'
+TRACKBAR_NAMES = ['Umbral','Area minima','Distancia max','Max blobs','Historial','Varianza','Caja B','Caja G','Caja R']
+
+
+def save_trackbar_settings(path=SETTINGS_FILE):
+    data = {name: cv2.getTrackbarPos(name, 'Controls') for name in TRACKBAR_NAMES}
+    with open(path, 'w') as f:
+        json.dump(data, f)
+    print(f'Trackbar settings saved to {path}')
+
+
+def load_trackbar_settings(path=SETTINGS_FILE):
+    if not os.path.exists(path):
+        return False
+    with open(path, 'r') as f:
+        data = json.load(f)
+    for name, val in data.items():
+        if name in TRACKBAR_NAMES:
+            cv2.setTrackbarPos(name, 'Controls', int(val))
+    print(f'Trackbar settings loaded from {path}')
+    return True
 
 
 # Core classes
@@ -132,6 +159,7 @@ if __name__=='__main__':
     if not ret: exit()
     h, w = frame.shape[:2]
     create_control_panel()
+    load_trackbar_settings()
     cv2.namedWindow('Preview', cv2.WINDOW_NORMAL)
 
     pre = Preprocessor(500,16); det=BlobDetector(500); trk=Tracker(50)
@@ -168,6 +196,10 @@ if __name__=='__main__':
 
         cv2.imshow('Preview',mosaic)
         key=cv2.waitKey(1)&0xFF
+        if key==ord('s'):
+            save_trackbar_settings()
+        if key==ord('l'):
+            load_trackbar_settings()
         if key==ord('e') and not exporting:
             exporting=True
             writer=cv2.VideoWriter(out_frames, cv2.VideoWriter_fourcc(*'mp4v'), vs.fps, (w,h))


### PR DESCRIPTION
## Summary
- allow saving and loading trackbar positions to a JSON file
- add keyboard shortcuts `s` and `l` to save/load settings
- document the new shortcuts in the help panel

## Testing
- `python -m py_compile blob_tracker.py`


------
https://chatgpt.com/codex/tasks/task_b_689ce1fb9c6c832cbfcee5838eaea352