### PR TITLE
feat: add ROI selection and motion trails with CSV logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,12 @@
   * **Foreground Segmentation:** Uses the MOG2 algorithm for background subtraction to create a foreground mask.
   * **Blob Detection:** Identifies contours in the foreground mask and filters out those below a defined minimum area.
   * **Object Tracking:** Uses a cost matrix with the Hungarian algorithm to assign detections to tracked objects, with an optional Kalman filter for smoother position estimates.
-  * **Real-time Control Panel:** Allows dynamic adjustment of key parameters such as threshold, minimum blob area, maximum tracking distance, maximum number of blobs, background subtractor history, variance threshold, bounding box color, and Kalman filtering.
+  * **ROI Selection:** Define a rectangular region of interest to focus detection and tracking.
+  * **Per-object Colors & Motion Trails:** Each object receives a unique color and an optional trail showing recent positions.
+  * **Real-time Control Panel:** Adjust threshold, minimum blob area, maximum tracking distance, number of blobs, background subtractor history, variance threshold, Kalman filtering, and trail visualization.
+  * **Preset Persistence:** Save and load control-panel settings with keyboard shortcuts.
   * **Mosaic Visualization:** Simultaneously displays the original frame, foreground mask, clean mask, and the output frame with tracked objects.
-  * **Video Export:** Exports the processed video to a new MP4 file, complete with a progress bar.
+  * **Video & CSV Export:** Exports the processed video to a new MP4 file and logs tracked positions to a CSV.
   * **Audio Merging:** Automatically combines the audio from the original video with the exported video.
 
 ## 3\. Requirements
@@ -55,11 +58,13 @@ pip install opencv-python numpy scipy moviepy tqdm
       * **Kalman:** Toggle (0/1) for applying Kalman filter smoothing to tracked positions.
       * **Historial:** Length of history for the MOG2 background subtraction algorithm.
       * **Varianza:** Variance threshold for the MOG2 background subtraction algorithm.
-      * **Caja B, Caja G, Caja R:** BGR components of the bounding box and object ID color.
-5.  **Help Window:** A separate "Ayuda" window summarizes these controls and lists key commands (`e` to export, `q` to quit).
+      * **Ver rastro:** Toggle (0/1) to show motion trails.
+      * **Len rastro:** Number of recent positions drawn in the trail.
+5.  **Help Window:** A separate "Ayuda" window summarizes these controls and lists key commands (`s` to save, `l` to load, `r` to select/reset ROI, `e` to export, `q` to quit).
 6.  **Preview Window:** The "Preview" window will display the mosaic visualization of the processing output with quadrant labels (Original, Mascara FG, Mascara limpia y Salida).
 7.  **Export Video:** Press the `e` key while the "Preview" window is active to start video export. A progress bar will appear in the console. Once frame export is complete, audio will be merged with the video. The final output file will have `_with_audio.mp4` appended to its name.
 8.  **Quit:** Press the `q` key to close all windows and exit the program.
+9.  **CSV Log:** Upon exit, a CSV file with tracked positions is saved alongside the video (`*_tracks.csv`).
 
 
 ## 5\. Code Structure
@@ -71,8 +76,8 @@ The script is organized into several functions and classes to modularize the dif
   * **`VideoSource`:** Class to encapsulate video file reading and management.
   * **`Preprocessor`:** Class responsible for background subtraction and image preprocessing.
   * **`BlobDetector`:** Class for detecting blobs (contours) in the preprocessed mask.
-  * **`Tracker`:** Class that manages the tracking of multiple objects, using the Hungarian algorithm for assignment and an optional Kalman filter to smooth positions.
-  * **`Visualizer`:** Static class for drawing tracking results on the frame.
+  * **`Tracker`:** Class that manages the tracking of multiple objects, using the Hungarian algorithm for assignment, optional Kalman filters, and per-object colors and trails.
+  * **`Visualizer`:** Static class for drawing tracking results and optional motion trails on the frame.
   * **`if __name__ == '__main__':` (Main Block):** The main loop that initializes classes, reads frames, applies processing, updates parameters from the control panel, and manages visualization and export.
 
 ## 6\. Core Classes
@@ -98,12 +103,12 @@ The script is organized into several functions and classes to modularize the dif
 
 ### `Tracker`
 
-  * **`__init__(self, max_dist, use_kalman=False)`:** Initializes the tracker with the maximum assignment distance, optional Kalman filtering, the next available object ID, and dictionaries of tracked objects and filters.
-  * **`update(self, detections, max_blobs)`:** Builds a cost matrix between detections and existing objects and uses the Hungarian algorithm for assignment. New objects receive IDs, and, if enabled, a Kalman filter smooths the reported position. Returns a list of tracked detections with IDs.
+  * **`__init__(self, max_dist, use_kalman=False)`:** Initializes the tracker with the maximum assignment distance, optional Kalman filtering, and stores object states, colors, and trails.
+  * **`update(self, detections, max_blobs, trail_len)`:** Builds a cost matrix between detections and existing objects and uses the Hungarian algorithm for assignment. New objects receive IDs and colors; trails are trimmed to `trail_len`. Returns a list of tracked detections with IDs, colors, and trails.
 
 ### `Visualizer`
 
-  * **`draw(frame, tracks, color)` (static method):** Draws bounding boxes and IDs for each tracked object on the frame.
+  * **`draw(frame, tracks, show_trails)` (static method):** Draws per-object bounding boxes, IDs, and optionally motion trails on the frame.
 
 ## 7\. Control Panel
 
@@ -117,7 +122,8 @@ The "Controls" panel allows for real-time manipulation of the following paramete
   * **Kalman:** Turns Kalman filter smoothing on (1) or off (0) for tracked positions.
   * **Historial:** The `history` parameter for `cv2.createBackgroundSubtractorMOG2`. How many frames are used for the background model.
   * **Varianza:** The `varThreshold` parameter for `cv2.createBackgroundSubtractorMOG2`. Determines how far a pixel can be from the mean to be considered foreground.
-  * **Caja B, Caja G, Caja R:** BGR values for the color of the drawn bounding boxes.
+  * **Ver rastro:** Toggles the drawing of motion trails.
+  * **Len rastro:** Number of points kept in each trail.
 
 
 ## 8\. Video Export


### PR DESCRIPTION
## Summary
- add trackbar presets for trail visualization and length
- allow mouse-based ROI selection to focus tracking
- assign per-object colors, draw motion trails, and export track data to CSV

## Testing
- `python -m py_compile blob_tracker.py`

------
https://chatgpt.com/codex/tasks/task_b_689ce0db1fb4832cb0cbfdb0b5805871